### PR TITLE
Add additional options 

### DIFF
--- a/cmd/directories.go
+++ b/cmd/directories.go
@@ -142,14 +142,19 @@ func getClusterParams(basePath string, targetPath string) []string {
 
 }
 
-func renderClusterParams(cmd *cobra.Command, clusterName string, componentName string) string {
-	if clusterName == "" {
-		log.Fatal("Please specify a cluster name")
+func renderClusterParams(cmd *cobra.Command, clusterName string, componentName string, clusterParams string) string {
+	if clusterName == "" && clusterParams == "" {
+		log.Fatal("Please specify a --cluster name and/or --clusterparams")
 	}
 
-	clusterPath := getCluster(clusterDir, clusterName)
-
-	params := getClusterParams(clusterDir, clusterPath)
+	var params []string
+	if clusterName != "" {
+		clusterPath := getCluster(clusterDir, clusterName)
+		params = getClusterParams(clusterDir, clusterPath)
+	}
+	if clusterParams != "" {
+		params = append(params, clusterParams)
+	}
 
 	j := renderJsonnet(cmd, params, "", true, "")
 	if componentName != "" {

--- a/cmd/jsonnet.go
+++ b/cmd/jsonnet.go
@@ -256,5 +256,5 @@ func init() {
 	renderCmd.PersistentFlags().StringVarP(&outputFormat, "format", "F", "json", "Output forma: json, yaml, stream")
 
 	renderCmd.PersistentFlags().StringP("cluster", "c", "", "cluster to render params for")
-	viper.BindPFlag("cluster", clusterCmd.PersistentFlags().Lookup("cluster"))
+	viper.BindPFlag("cluster", renderCmd.PersistentFlags().Lookup("cluster"))
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,10 +31,12 @@ import (
 )
 
 var (
-	cfgFile     string
-	base        string
-	debug       bool
-	colorOutput bool
+	cfgFile      string
+	baseDir      string
+	clusterDir   string
+	componentDir string
+	debug        bool
+	colorOutput  bool
 )
 
 // exported Version variable
@@ -64,12 +66,15 @@ func Execute(version string) {
 func init() {
 	cobra.OnInitialize(initConfig)
 
-	RootCmd.PersistentFlags().StringVarP(&base, "base", "d", ".", "kr8 config base directory")
+	RootCmd.PersistentFlags().StringVarP(&baseDir, "base", "d", ".", "kr8 config base directory")
+	RootCmd.PersistentFlags().StringVarP(&clusterDir, "clusterdir", "D", "", "kr8 cluster directory")
+	RootCmd.PersistentFlags().StringVarP(&componentDir, "componentdir", "X", "", "kr8 component directory")
 	RootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "log more information about what kr8 is doing")
 	RootCmd.PersistentFlags().BoolVar(&colorOutput, "color", false, "enable colorized output")
 	RootCmd.PersistentFlags().StringArrayP("jpath", "J", nil, "Directories to add to jsonnet include path. Repeat arg for multiple directories")
 	RootCmd.PersistentFlags().StringSlice("ext-str-file", nil, "Set jsonnet extvar from file contents")
 	viper.BindPFlag("base", RootCmd.PersistentFlags().Lookup("base"))
+	viper.BindPFlag("clusterdir", RootCmd.PersistentFlags().Lookup("clusterdir"))
 }
 
 // initConfig reads in config file and ENV variables if set.
@@ -88,8 +93,17 @@ func initConfig() {
 	viper.SetEnvPrefix("KR8")
 	viper.AutomaticEnv() // read in environment variables that match
 
-	base = viper.GetString("base")
-	log.Debug("Using base directory: ", base)
+	baseDir = viper.GetString("base")
+	log.Debug("Using base directory: ", baseDir)
+	clusterDir = viper.GetString("clusterdir")
+	if clusterDir == "" {
+		clusterDir = baseDir + "/clusters"
+	}
+	log.Debug("Using cluster directory: ", clusterDir)
+	if componentDir == "" {
+		componentDir = baseDir + "/components"
+	}
+	log.Debug("Using component directory: ", componentDir)
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {
 		log.Debug("Using config file:", viper.ConfigFileUsed())

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -75,6 +75,7 @@ func init() {
 	RootCmd.PersistentFlags().StringSlice("ext-str-file", nil, "Set jsonnet extvar from file contents")
 	viper.BindPFlag("base", RootCmd.PersistentFlags().Lookup("base"))
 	viper.BindPFlag("clusterdir", RootCmd.PersistentFlags().Lookup("clusterdir"))
+	viper.BindPFlag("componentdir", RootCmd.PersistentFlags().Lookup("componentdir"))
 }
 
 // initConfig reads in config file and ENV variables if set.


### PR DESCRIPTION
Adds three new options

1. `--clusterdir <directory>` specify the path to the cluster directory. This overrides the default of KR8_BASE/clusters
2. `--componentdir <directory>` specify the path to the component directory. This overrides the default of KR8_BASE/components
3. `--clusterparams <filepath.jsonnet` provide a jsonnet file that should contain cluster parameters. It can be combined with `--cluster <clustername>` to specify overrides or additional parameters to be added ahead of the parameters defined by the cluster. It can also be used separately without specifying `--cluster <clustername` at all.

These options are primarily meant to help with testing, but also enhance the possible ways that kr8 could be used.

In addition to this, when defining components to include in "_components", which would normally look like this:
```
{
  _components: {
    componentinstance1: { path: 'components/component1' },
    componentinstance2: { path: 'components/component2' },
  }
```

can now be specified like this instead
```
{
  _components: {
    componentinstance1: { component: 'component1' },
    componentinstance2: { component: 'component2' },
  }
```
and the components will be looked for in the component directory. The intention is to later expand clusterdir, to add multiple search locations, and probably deprecate the "path" field.
