### PR TITLE
adding clean up orphaned components in genCluster proc

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -132,6 +132,9 @@ func genProcessCluster(cmd *cobra.Command, clusterName string, p *ants.Pool) {
 		if _, found := tmpMap[e]; !found {
 			delcomp := filepath.Join(clusterDir, e)
 			os.RemoveAll(delcomp)
+			log.Info().Str("cluster", clusterName).
+				Str("component", e).
+				Msg("Deleting generated for component")
 		}
 	}
 

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -2,13 +2,6 @@ package cmd
 
 import (
 	"encoding/json"
-	goyaml "github.com/ghodss/yaml"
-	jsonnet "github.com/google/go-jsonnet"
-	"github.com/panjf2000/ants/v2"
-	"github.com/rs/zerolog/log"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-	"github.com/tidwall/gjson"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -18,6 +11,14 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+
+	goyaml "github.com/ghodss/yaml"
+	jsonnet "github.com/google/go-jsonnet"
+	"github.com/panjf2000/ants/v2"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/tidwall/gjson"
 )
 
 type safeString struct {
@@ -83,25 +84,53 @@ func genProcessCluster(cmd *cobra.Command, clusterName string, p *ants.Pool) {
 
 	// determine list of components to process
 	var compList []string
+	var currentCompList []string
+
 	if components != "" {
 		// only process specified component if it's defined in the cluster
-		for c, _ := range clusterComponents {
-			for _, b := range strings.Split(components, ",") {
+		for _, b := range strings.Split(components, ",") { //flipped so it could append to currentCompList first
+			currentCompList = append(currentCompList, b)
+			for c, _ := range clusterComponents {
 				matched, _ := regexp.MatchString("^"+b+"$", c)
 				if matched {
 					compList = append(compList, c)
 				}
 			}
 		}
-		if len(compList) == 0 {
-			return
-		}
 	} else {
 		for c, _ := range clusterComponents {
 			compList = append(compList, c)
 		}
+		// list of current generated components directories
+		d, err := os.Open(clusterDir)
+		if err != nil {
+			log.Fatal().Err(err).Msg("")
+		}
+		defer d.Close()
+		read_all_dirs := -1
+		currentCompList, err = d.Readdirnames(read_all_dirs)
+		if err != nil {
+			log.Fatal().Err(err).Msg("")
+		}
 	}
 	sort.Strings(compList) // process components in sorted order
+
+	// Sort out orphaned generated components directories
+	tmpMap := make(map[string]struct{}, len(clusterComponents)) // using temp map was faster and only works when comparing two slices
+	for e, _ := range clusterComponents {
+		tmpMap[e] = struct{}{}
+	}
+
+	for _, e := range currentCompList {
+		if _, found := tmpMap[e]; !found {
+			delcomp := filepath.Join(clusterDir, e)
+			os.RemoveAll(delcomp)
+		}
+	}
+
+	if len(compList) == 0 { // this needs to be moved so purging above works first
+		return
+	}
 
 	// render full params for cluster for all selected components
 	config := renderClusterParams(cmd, clusterName, compList, clusterParams, false)


### PR DESCRIPTION
Cleanup of generated component directory which are no longer defined in _cluster will be done as follows:

- if kr8 generate , finds orphaned components directories and deletes them
- kr8 generate --clusters XXX will do cleanup of cluster XXX
- kr8 generate --clusters XXX --components YYY will clean up of component YYY if it is orphaned
- kr8 generate --components ZZZ will do cleanup of all the cluster if ZZZ is orphaned 

components clean up will work with regex as well
```
~/git/kr8/kr8 generate --components action.+
git status
On branch master
Your branch is up to date with 'origin/master'.

Changes not staged for commit:
  (use "git add/rm <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   clusters/development/TTT/UUU/VVVV/cluster.jsonnet
	deleted:    generated/XXX//actions_runner/00_namespace.yaml
	deleted:    generated/XXX//actions_runner/runners.yaml
	deleted:    generated/XXX//actions_runner/service_accounts.yaml
	deleted:    generated/XXX//actions_runner_ctlr/00_namespace.yaml
	deleted:    generated/XXX//actions_runner_ctlr/actions-runner-controller.yaml
	deleted:    generated/XXX//actions_runner_ctlr/actions.summerwind.dev_horizontalrunnerautoscalers.yaml
	deleted:    generated/XXX//actions_runner_ctlr/actions.summerwind.dev_runnerdeployments.yaml
	deleted:    generated/XXX//actions_runner_ctlr/actions.summerwind.dev_runnerreplicasets.yaml
	deleted:    generated/XXX/actions_runner_ctlr/actions.summerwind.dev_runners.yaml
	deleted:    generated/XXX/actions_runner_ctlr/actions.summerwind.dev_runnersets.yaml
	deleted:    generated/XXX/actions_runner_ctlr/podmonitor.yaml

no changes added to commit (use "git add" and/or "git commit -a")
~/git/kr8-configs   master !12
```

also now showing logs for deleting orphaned generated dir for components upon generating
```
❯ ~/git/kr8/kr8 generate --components ossec
1:19PM INF Deleting generated for component cluster=XXXXX component=ossec

❯ ~/git/kr8/kr8 generate --clusters XXXX
1:19PM INF Deleting generated for component cluster=XXXX component=ossec
1:19PM INF Process component cluster=XXXX component=audit
1:19PM INF Process component cluster=XXXX component=alexandria
1:19PM INF Process component cluster=XXXX component=actions_runner_ctlr
1:19PM INF Process component cluster=XXXX component=apptioconnect
1:19PM INF Process component cluster=XXXX component=arg
```