### PR TITLE
kubernetes-helm brew dependency is deprecated, updated to helm

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -66,6 +66,6 @@ brews:
       bin.install "kr8"
       bin.install "scripts/kr8-helpers"
     dependencies:
-      - kubernetes-helm
+      - helm
       - jsonnet
       - go-task/tap/go-task


### PR DESCRIPTION
In brew: https://formulae.brew.sh/formula/helm#default

"Formerly known as: kubernetes-helm"

Problem:  When installing with brew, get numerous warnings:

```
==> Installing apptio/tap/kr8
Warning: Use helm instead of deprecated kubernetes-helm
Warning: Use helm instead of deprecated kubernetes-helm
Warning: Use helm instead of deprecated kubernetes-helm
Warning: Use helm instead of deprecated kubernetes-helm
Warning: Use helm instead of deprecated kubernetes-helm
Warning: Use helm instead of deprecated kubernetes-helm
Warning: Use helm instead of deprecated kubernetes-helm
Warning: Use helm instead of deprecated kubernetes-helm
Warning: Use helm instead of deprecated kubernetes-helm
Warning: Use helm instead of deprecated kubernetes-helm
Warning: Use helm instead of deprecated kubernetes-helm
Warning: Use helm instead of deprecated kubernetes-helm
🍺  /home/linuxbrew/.linuxbrew/Cellar/kr8/0.3.4: 7 files, 26.7MB, built in 1 second
```